### PR TITLE
Allow meteor release to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - **-c, --config [config-file]** - The path for the bundler config file. Defaults to `meteor-client.config.json`. An example config can be found in the [examples section](#examples). The config can contain the following fields:
   - **runtime** - Meteor’s runtime config. Most commonly used to set the URL of the Meteor server we would like to interface with, which defaults to `localhost:3000`.
   - **import** - A list of packages we would like to include in our bundle. Will most likely contain the `meteor-base` package, as it’s the core file of Meteor’s client, and without it, there will be no Meteor whatsoever.
+- **-r, --release [meteor-release]** - Define which Meteor release to use. Default is to download most recent stable version.
 - **--url** - DDP default connection URL.
 - **--packs-dir** - Export `METEOR_PACKAGE_DIRS`. Defaults to the `packages` directory under the root directory of the project. For more information, see [reference](https://docs.meteor.com/environment-variables.html#METEOR-PACKAGE-DIRS).
 

--- a/cli
+++ b/cli
@@ -29,6 +29,10 @@ Program
     "The path for the bundler config file. Defaults to \"meteor-client.config.json\""
   ].join("\n" + optionIndention))
 
+  .option("-r, --release [meteor-release]", [
+    "Define which Meteor release to use. Default is to download most recent stable version."
+  ].join("\n" + optionIndention))
+
   .option("--url [connection-url]", [
     "DDP default connection URL"
   ].join("\n" + optionIndention))
@@ -42,7 +46,7 @@ Program
     Bundler.bundle(options);
   });
 
-Program.on("--help", function (){
+Program.on("--help", function () {
   console.log(titleIndention + "For more information, see: " + Pack.repository.url);
   console.log();
 });

--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -32,9 +32,18 @@ function bundle(options) {
   var tempDir = Tmp.dirSync({ unsafeCleanup: true }).name;
 
   // Create a dummy Meteor project in temp dir
-  Execa.sync("meteor", ["create", tempDir], {
-    stdio: "inherit"
-  });
+  if (!options.release) {
+    Execa.sync("meteor", ["create", tempDir], {
+      stdio: "inherit"
+    });
+
+  }
+  // If a release is provided, specify it on creation.
+  else {
+    Execa.sync("meteor", ["create", "--release", options.release, tempDir], {
+      stdio: "inherit"
+    });
+  }
 
   try {
     var userConfig = require(configFile);
@@ -109,8 +118,8 @@ function bundle(options) {
     // Keep client's packages files
     .filter(function (pack) {
       return pack.where == "client" &&
-             pack.type == "js" &&
-             Path.dirname(pack.path) == "packages"
+        pack.type == "js" &&
+        Path.dirname(pack.path) == "packages"
     })
     // Append each package to destination file
     .forEach(function (pack) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor-client-bundler",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Bundles Meteor client-packages into a single module",
   "author": "Eytan Manor",
   "repository": {


### PR DESCRIPTION
These changes add a parameter for the meteor release to the cli. In this way, one can make sure, the same Meteor version is used on server and client. Maybe, it would be reasonable to include this in the config file.