### PR TITLE
run test using npm instead of make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,0 @@
-mocha_path := node_modules/mocha/bin/mocha
-
-test:
-	$(mocha_path) test/index --timeout=100000
-
-.PHONY: test

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "meteor-client": "cli"
   },
   "scripts": {
-    "test": "make test"
+    "test": "mocha test/index --timeout=100000"
   },
   "dependencies": {
     "babel-core": "^6.24.0",


### PR DESCRIPTION
This PR allows users to run test without installing `make`.

