### PR TITLE
Adjusting dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "execa": "^0.6.0",
     "find-root": "^1.0.0",
     "merge": "^1.2.0",
+    "rimraf": "^2.5.4",
     "tmp": "0.0.31"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "fs-extra": "^2.0.0",
-    "mocha": "^3.2.0",
-    "rimraf": "^2.5.4"
+    "mocha": "^3.2.0"
   },
   "keywords": [
     "meteor",


### PR DESCRIPTION
Hi,

We found the publish npm package of this project was failing when we went to do a build - it was complaining about a missing package 'rimraf'. We found that the package.json should specify this as a required dependency instead of a devDependency. 

If you could accept and push this change to npm we would appreciate.