### PR TITLE
Ability to rewrite settings on import

### DIFF
--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -120,8 +120,8 @@ function bundle(options) {
   });
 
   // A necessary code snippet so the Meteor client can work properly
-  var runtimeconfig = "__meteor_runtime_config__ = " +
-    JSON.stringify(config["runtime"], null, 2) + ";\n\n";
+  var runtimeconfig = "__meteor_runtime_config__ = Object.assign(" +
+    JSON.stringify(config["runtime"], null, 2) + ", window.__meteor_runtime_config__);\n\n";
 
   // In case we bundle into node_modules, ensue its existence
   if (!options.destination || config.generateNodeModules) {


### PR DESCRIPTION
now we could write code like
```
window.__meteor_runtime_config__ = {
  DDP_DEFAULT_CONNECTION_URL: 'http://example.com',
};
require('meteor-client');
```
to rewrite config settings. Sometimes it is much handier than rebuild full bundle just to reconfigure a bit.